### PR TITLE
Denying user location prevents loading screen from completing

### DIFF
--- a/screens/LoadingScreen.tsx
+++ b/screens/LoadingScreen.tsx
@@ -16,6 +16,13 @@ export default function LoadingScreen({ navigation }: Props<"LoadingScreen">) {
         getUserLocation()
             .then((result) => {
                 if (!result) {
+                    setCache((cache) => {
+                        return {
+                            ...cache,
+                            userLocation: { latitude: 0, longitude: 0 },
+                        };
+                    });
+
                     return "Carlisle";
                 }
 
@@ -71,7 +78,7 @@ export default function LoadingScreen({ navigation }: Props<"LoadingScreen">) {
 
     function gotEverything() {
         if (
-            cache.userLocation &&
+            // cache.userLocation &&
             cache.cities &&
             cache.currentCity &&
             cache.cityShops


### PR DESCRIPTION
For now, the user location defaults to 0, 0. Later on, I'll try to make user location fully optional across the entire app.