### PR TITLE
Fix login animation

### DIFF
--- a/screens/LoginPage.tsx
+++ b/screens/LoginPage.tsx
@@ -12,7 +12,6 @@ const LoginPage = ({ navigation }: Props<"LoginPage">) => {
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [loginErr, setLoginErr] = useState<boolean>(false);
-
     const [loginSuccesful, setLoginSuccessful] = useState<boolean>(false);
 
     function handleLogin() {
@@ -23,14 +22,14 @@ const LoginPage = ({ navigation }: Props<"LoginPage">) => {
             .then(({ data: { user } }) => {
                 if (user.password === password && user.username === username) {
                     setLoginErr(false);
-                    setCache((cache) => {
-                        return { ...cache, user };
-                    });
                     setUsername("");
                     setPassword("");
                     setLoginSuccessful(true);
                     setTimeout(() => {
                         navigation.navigate("ShopSearch");
+                        setCache((cache) => {
+                            return { ...cache, user };
+                        });
                         setLoginSuccessful(false);
                     }, 3000);
                 } else {
@@ -41,6 +40,7 @@ const LoginPage = ({ navigation }: Props<"LoginPage">) => {
                 setLoginErr(true);
             });
     }
+
     if (loginSuccesful) {
         return (
             <View className="flex-1 items-center justify-center">

--- a/screens/LoginPage.tsx
+++ b/screens/LoginPage.tsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
-import axios from "axios";
-import { Props } from "./types";
 import * as Animatable from "react-native-animatable";
 import { AntDesign } from "@expo/vector-icons";
+
 import { useCache } from "../contexts/Cache";
+import { getUser } from "../utils/api";
+
+import { Props } from "./types";
 
 const LoginPage = ({ navigation }: Props<"LoginPage">) => {
-    const { cache, setCache } = useCache();
+    const { setCache } = useCache();
 
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
@@ -15,16 +17,14 @@ const LoginPage = ({ navigation }: Props<"LoginPage">) => {
     const [loginSuccesful, setLoginSuccessful] = useState<boolean>(false);
 
     function handleLogin() {
-        return axios
-            .get(
-                `https://coffee-connoisseur-api.onrender.com/api/users/${username}`
-            )
-            .then(({ data: { user } }) => {
+        getUser(username)
+            .then((user) => {
                 if (user.password === password && user.username === username) {
-                    setLoginErr(false);
                     setUsername("");
                     setPassword("");
+                    setLoginErr(false);
                     setLoginSuccessful(true);
+
                     setTimeout(() => {
                         navigation.navigate("ShopSearch");
                         setCache((cache) => {
@@ -63,7 +63,6 @@ const LoginPage = ({ navigation }: Props<"LoginPage">) => {
 
     return (
         <View className="bg-white mx-6 rounded-3xl mt-16">
-            {cache.user && <Text>hello</Text>}
             {loginErr && (
                 <Text className="text-center mt-10  mx-10 bg-red-300 rounded">
                     Looks like either your email address or password were
@@ -93,7 +92,7 @@ const LoginPage = ({ navigation }: Props<"LoginPage">) => {
                 Not a coffee connoisseur just yet?
             </Text>
             <Pressable
-                onPress={(nav) => navigation.navigate("SignUpPage")}
+                onPress={() => navigation.navigate("SignUpPage")}
                 className="mb-10"
             >
                 <Text className="text-center hover:text-white font-bold 	">


### PR DESCRIPTION
When the user successfully logs in, the navigation drawer removes the Login Page and replaces it with the Profile Page. This causes the app to immediately switch to a different screen in the navigation drawer because the Login Page is no longer "available". Because of this, the sign-in animation does not show up.

The fix is to delay when the cache is updated with the details of the logged-in user. That way, the Login Page remains in the navigation drawer until the animation ends and, only after navigating to the ShopSearch Page, does it remove the Login Page.